### PR TITLE
Fixed Issues caused by using RestServer::AddClass with an object

### DIFF
--- a/source/Jacwright/RestServer/RestServer.php
+++ b/source/Jacwright/RestServer/RestServer.php
@@ -135,11 +135,11 @@ class RestServer {
 		list($obj, $method, $params, $this->params, $noAuth) = $this->findUrl();
 
 		if ($obj) {
-			if (is_string($obj) && !($newObj = $this->instantiateClass($obj))) {
-				throw new Exception("Class $obj does not exist");
+			if (is_string($obj)) {
+                if($newObj = $this->instantiateClass($obj))  $obj = $newObj;
+				else throw new Exception("Class $obj does not exist");
 			}
 
-			$obj = $newObj;
 			$obj->server = $this;
 
 			try {


### PR DESCRIPTION
$obj = $newObj was always assigned, even when the class wasn't new, causing undefined variable errors and the script to fail from a fatal error.

Now $obj will only be changed when a new object is instantiated